### PR TITLE
Makes go-metaforce compatible with current version of go-soapforce

### DIFF
--- a/client.go
+++ b/client.go
@@ -196,3 +196,19 @@ func (client *Client) DeployRecentValidation(validationId string) (*DeployRecent
 		ValidationId: ID(validationId),
 	})
 }
+
+func (client *Client) ReadMetadataInto(typeName string, fullNames []string, response any) error {
+	request := ReadMetadata{
+		FullNames: fullNames,
+		Type:      typeName,
+	}
+	return client.portType.ReadMetadataInto(&request, response)
+}
+
+func (service *MetadataPortType) ReadMetadataInto(request *ReadMetadata, response any) error {
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/client.go
+++ b/client.go
@@ -205,10 +205,3 @@ func (client *Client) ReadMetadataInto(typeName string, fullNames []string, resp
 	return client.portType.ReadMetadataInto(&request, response)
 }
 
-func (service *MetadataPortType) ReadMetadataInto(request *ReadMetadata, response interface{}) error {
-	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
-	if err != nil {
-		return err
-	}
-	return nil
-}

--- a/client.go
+++ b/client.go
@@ -46,6 +46,17 @@ func (c *Client) SetAccessToken(sid string) {
 	c.portType.SetHeader(sessionHeader)
 }
 
+func (c *Client) GetSessionID() string {
+	if c.loginResult == nil {
+		return ""
+	}
+	return c.loginResult.SessionId
+}
+
+func (c *Client) GetServerURL() string {
+	return c.portType.client.GetServerUrl()
+}
+
 func (c *Client) SetLoginUrl(url string) {
 	c.LoginUrl = url
 	c.setLoginUrl()

--- a/client.go
+++ b/client.go
@@ -197,7 +197,7 @@ func (client *Client) DeployRecentValidation(validationId string) (*DeployRecent
 	})
 }
 
-func (client *Client) ReadMetadataInto(typeName string, fullNames []string, response any) error {
+func (client *Client) ReadMetadataInto(typeName string, fullNames []string, response interface{}) error {
 	request := ReadMetadata{
 		FullNames: fullNames,
 		Type:      typeName,
@@ -205,7 +205,7 @@ func (client *Client) ReadMetadataInto(typeName string, fullNames []string, resp
 	return client.portType.ReadMetadataInto(&request, response)
 }
 
-func (service *MetadataPortType) ReadMetadataInto(request *ReadMetadata, response any) error {
+func (service *MetadataPortType) ReadMetadataInto(request *ReadMetadata, response interface{}) error {
 	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/tzmfreedom/go-metaforce
 
 go 1.13
 
-require github.com/tzmfreedom/go-soapforce v0.0.0-20191110104759-5183224c84e2
+require github.com/tzmfreedom/go-soapforce v0.1.6

--- a/main/main.go
+++ b/main/main.go
@@ -1,15 +1,16 @@
 package main
 
 import (
+	"os"
+
 	"github.com/k0kubun/pp"
 	"github.com/tzmfreedom/go-metaforce"
-	"os"
 )
 
 var client *metaforce.Client
 
 func main() {
-	client = metaforce.NewClient("", "47.0")
+	client = metaforce.NewClient()
 	client.SetDebug(true)
 	err := client.Login(os.Getenv("SALESFORCE_USERNAME"), os.Getenv("SALESFORCE_PASSWORD"))
 	if err != nil {
@@ -33,7 +34,7 @@ func listMetadata() {
 }
 
 func readMetadata() {
-	res, err := client.ReadMetadata("CustomObject", []string{ "GO__c" })
+	res, err := client.ReadMetadata("CustomObject", []string{"GO__c"})
 	if err != nil {
 		panic(err)
 	}
@@ -43,17 +44,17 @@ func readMetadata() {
 func createMetadata() {
 	request := []metaforce.MetadataInterface{
 		&metaforce.CustomObject{
-			FullName: "GO222__c",
-			Type: "CustomObject",
+			FullName:         "GO222__c",
+			Type:             "CustomObject",
 			DeploymentStatus: metaforce.DeploymentStatusDeployed,
-			Description: "これはGOから作ってるよ",
-			Label: "GOミラクルオブジェクト",
+			Description:      "これはGOから作ってるよ",
+			Label:            "GOミラクルオブジェクト",
 			NameField: &metaforce.CustomField{
-				Label: "GO名",
+				Label:  "GO名",
 				Length: 80,
-				Type: metaforce.FieldTypeText,
+				Type:   metaforce.FieldTypeText,
 			},
-			PluralLabel: "GOミラクルオブジェクツ",
+			PluralLabel:  "GOミラクルオブジェクツ",
 			SharingModel: metaforce.SharingModelReadWrite,
 		},
 	}
@@ -65,7 +66,7 @@ func createMetadata() {
 }
 
 func deleteMetadata() {
-	res, err := client.DeleteMetadata("CustomObject", []string{ "GO222__c" })
+	res, err := client.DeleteMetadata("CustomObject", []string{"GO222__c"})
 	if err != nil {
 		panic(err)
 	}
@@ -74,11 +75,11 @@ func deleteMetadata() {
 
 func retrieve() {
 	res, err := client.Retrieve(&metaforce.RetrieveRequest{
-		ApiVersion: 37.0,
-		PackageNames: []string{"CustomObject"},
+		ApiVersion:    37.0,
+		PackageNames:  []string{"CustomObject"},
 		SinglePackage: true,
 		SpecificFiles: []string{},
-		Unpackaged: nil,
+		Unpackaged:    nil,
 	})
 	if err != nil {
 		panic(err)
@@ -104,7 +105,7 @@ func describeValueType() {
 
 func renameMetadata() {
 	res, err := client.RenameMetadata(&metaforce.RenameMetadata{
-		Type: "CustomObject",
+		Type:        "CustomObject",
 		OldFullName: "GO1__c",
 		NewFullName: "GO2__c",
 	})
@@ -117,17 +118,17 @@ func renameMetadata() {
 func updateMetadata() {
 	res, err := client.UpdateMetadata([]metaforce.MetadataInterface{
 		&metaforce.CustomObject{
-			FullName: "GO2__c",
-			Type: "CustomObject",
+			FullName:         "GO2__c",
+			Type:             "CustomObject",
 			DeploymentStatus: metaforce.DeploymentStatusDeployed,
-			Description: "これはGOから作ってるよ 2",
-			Label: "GOミラクルオブジェクト",
+			Description:      "これはGOから作ってるよ 2",
+			Label:            "GOミラクルオブジェクト",
 			NameField: &metaforce.CustomField{
-				Label: "GO名",
+				Label:  "GO名",
 				Length: 80,
-				Type: metaforce.FieldTypeText,
+				Type:   metaforce.FieldTypeText,
 			},
-			PluralLabel: "GOミラクルオブジェクツ",
+			PluralLabel:  "GOミラクルオブジェクツ",
 			SharingModel: metaforce.SharingModelReadWrite,
 		},
 	})
@@ -140,17 +141,17 @@ func updateMetadata() {
 func upsertMetadata() {
 	res, err := client.UpsertMetadata([]metaforce.MetadataInterface{
 		&metaforce.CustomObject{
-			FullName: "GO1__c",
-			Type: "CustomObject",
+			FullName:         "GO1__c",
+			Type:             "CustomObject",
 			DeploymentStatus: metaforce.DeploymentStatusDeployed,
-			Description: "これはGOから作ってるよ 3",
-			Label: "GOミラクルオブジェクト",
+			Description:      "これはGOから作ってるよ 3",
+			Label:            "GOミラクルオブジェクト",
 			NameField: &metaforce.CustomField{
-				Label: "GO名",
+				Label:  "GO名",
 				Length: 80,
-				Type: metaforce.FieldTypeText,
+				Type:   metaforce.FieldTypeText,
 			},
-			PluralLabel: "GOミラクルオブジェクツ",
+			PluralLabel:  "GOミラクルオブジェクツ",
 			SharingModel: metaforce.SharingModelReadWrite,
 		},
 	})

--- a/metadata.go
+++ b/metadata.go
@@ -2,10 +2,11 @@ package metaforce
 
 import (
 	"encoding/xml"
-	"github.com/tzmfreedom/go-soapforce"
 	"io"
 	"net"
 	"time"
+
+	"github.com/tzmfreedom/go-soapforce"
 )
 
 // against "unused imports"
@@ -4778,7 +4779,7 @@ type RunTestSuccess struct {
 	Time float64 `xml:"time,omitempty"`
 }
 
-type MetadataInterface interface {}
+type MetadataInterface interface{}
 
 type Metadata struct {
 	FullName string `xml:"fullName,omitempty"`
@@ -12879,7 +12880,7 @@ type LoginResult struct {
 	Sandbox           bool   `xml:"sandbox`
 	ServerUrl         string `xml:"serverUrl"`
 	SessionId         string `xml:"sessionId"`
-	UserId            ID    `xml:"userId"`
+	UserId            ID     `xml:"userId"`
 	//	UserInfo *UserInfo `xml:"userInfo"`
 }
 
@@ -12921,7 +12922,7 @@ func (service *MetadataPortType) SetHeader(header interface{}) {
 /* Cancels a metadata deploy. */
 func (service *MetadataPortType) CancelDeploy(request *CancelDeploy) (*CancelDeployResponse, error) {
 	response := new(CancelDeployResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -12932,7 +12933,7 @@ func (service *MetadataPortType) CancelDeploy(request *CancelDeploy) (*CancelDep
 /* Check the current status of an asyncronous deploy call. */
 func (service *MetadataPortType) CheckDeployStatus(request *CheckDeployStatus) (*CheckDeployStatusResponse, error) {
 	response := new(CheckDeployStatusResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -12943,7 +12944,7 @@ func (service *MetadataPortType) CheckDeployStatus(request *CheckDeployStatus) (
 /* Check the current status of an asyncronous deploy call. */
 func (service *MetadataPortType) CheckRetrieveStatus(request *CheckRetrieveStatus) (*CheckRetrieveStatusResponse, error) {
 	response := new(CheckRetrieveStatusResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -12954,7 +12955,7 @@ func (service *MetadataPortType) CheckRetrieveStatus(request *CheckRetrieveStatu
 /* Creates metadata entries synchronously. */
 func (service *MetadataPortType) CreateMetadata(request *CreateMetadata) (*CreateMetadataResponse, error) {
 	response := new(CreateMetadataResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -12965,7 +12966,7 @@ func (service *MetadataPortType) CreateMetadata(request *CreateMetadata) (*Creat
 /* Deletes metadata entries synchronously. */
 func (service *MetadataPortType) DeleteMetadata(request *DeleteMetadata) (*DeleteMetadataResponse, error) {
 	response := new(DeleteMetadataResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -12977,7 +12978,7 @@ func (service *MetadataPortType) DeleteMetadata(request *DeleteMetadata) (*Delet
 func (service *MetadataPortType) Deploy(request *Deploy) (*DeployResponse, error) {
 	response := new(DeployResponse)
 	// modify
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -12988,7 +12989,7 @@ func (service *MetadataPortType) Deploy(request *Deploy) (*DeployResponse, error
 /* Deploys a previously validated payload without running tests. */
 func (service *MetadataPortType) DeployRecentValidation(request *DeployRecentValidation) (*DeployRecentValidationResponse, error) {
 	response := new(DeployRecentValidationResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -12999,7 +13000,7 @@ func (service *MetadataPortType) DeployRecentValidation(request *DeployRecentVal
 /* Describes features of the metadata API. */
 func (service *MetadataPortType) DescribeMetadata(request *DescribeMetadata) (*DescribeMetadataResponse, error) {
 	response := new(DescribeMetadataResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -13010,7 +13011,7 @@ func (service *MetadataPortType) DescribeMetadata(request *DescribeMetadata) (*D
 /* Describe a complex value type */
 func (service *MetadataPortType) DescribeValueType(request *DescribeValueType) (*DescribeValueTypeResponse, error) {
 	response := new(DescribeValueTypeResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -13021,7 +13022,7 @@ func (service *MetadataPortType) DescribeValueType(request *DescribeValueType) (
 /* Lists the available metadata components. */
 func (service *MetadataPortType) ListMetadata(request *ListMetadata) (*ListMetadataResponse, error) {
 	response := new(ListMetadataResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -13032,7 +13033,7 @@ func (service *MetadataPortType) ListMetadata(request *ListMetadata) (*ListMetad
 /* Reads metadata entries synchronously. */
 func (service *MetadataPortType) ReadMetadata(request *ReadMetadata) (*ReadMetadataResponse, error) {
 	response := new(ReadMetadataResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -13043,7 +13044,7 @@ func (service *MetadataPortType) ReadMetadata(request *ReadMetadata) (*ReadMetad
 /* Renames a metadata entry synchronously. */
 func (service *MetadataPortType) RenameMetadata(request *RenameMetadata) (*RenameMetadataResponse, error) {
 	response := new(RenameMetadataResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -13054,7 +13055,7 @@ func (service *MetadataPortType) RenameMetadata(request *RenameMetadata) (*Renam
 /* Retrieves a set of individually specified metadata entries. */
 func (service *MetadataPortType) Retrieve(request *Retrieve) (*RetrieveResponse, error) {
 	response := new(RetrieveResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -13065,7 +13066,7 @@ func (service *MetadataPortType) Retrieve(request *Retrieve) (*RetrieveResponse,
 /* Updates metadata entries synchronously. */
 func (service *MetadataPortType) UpdateMetadata(request *UpdateMetadata) (*UpdateMetadataResponse, error) {
 	response := new(UpdateMetadataResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -13076,7 +13077,7 @@ func (service *MetadataPortType) UpdateMetadata(request *UpdateMetadata) (*Updat
 /* Upserts metadata entries synchronously. */
 func (service *MetadataPortType) UpsertMetadata(request *UpsertMetadata) (*UpsertMetadataResponse, error) {
 	response := new(UpsertMetadataResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}
@@ -13087,7 +13088,7 @@ func (service *MetadataPortType) UpsertMetadata(request *UpsertMetadata) (*Upser
 /* Upserts metadata entries synchronously. */
 func (service *MetadataPortType) Login(request *LoginRequest) (*LoginResponse, error) {
 	response := new(LoginResponse)
-	err := service.client.Call(request, response)
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
 	if err != nil {
 		return nil, err
 	}

--- a/metadata.go
+++ b/metadata.go
@@ -13096,6 +13096,14 @@ func (service *MetadataPortType) Login(request *LoginRequest) (*LoginResponse, e
 	return response, nil
 }
 
+func (service *MetadataPortType) ReadMetadataInto(request *ReadMetadata, response interface{}) error {
+	err := service.client.Call(request, response, &soapforce.ResponseSOAPHeader{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 var timeout = time.Duration(30 * time.Second)
 
 func dialTimeout(network, addr string) (net.Conn, error) {


### PR DESCRIPTION
- Upgrades to v0.1.6 of go-soapforce
- Fixes the resultant issues: missing headers in calls to `Call`, and an incorrect constructor in `main.go`
- Runs modern `gofmt` on the code.